### PR TITLE
Add Kafka Consumer to Notification Service

### DIFF
--- a/src/main/java/org/example/notificationservice/service/NotificationService.java
+++ b/src/main/java/org/example/notificationservice/service/NotificationService.java
@@ -1,0 +1,14 @@
+package org.example.notificationservice.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class NotificationService {
+  @KafkaListener(topics = "notificationTopic", groupId = "notification-service-group")
+  public void listen(String orderId) {
+    log.info("Order received with order id : {}", orderId);
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces a Kafka consumer implementation in the Notification Service application.

### Changes:
- **Add NotificationService Class:** Created `NotificationService` class.
- **Add KafkaListener Annotation:** Added `@KafkaListener` annotation to the `listen` method in `NotificationService`.
- **Configure Kafka Topic and Group ID:** Configured the `listen` method to consume messages from the `notificationTopic` Kafka topic with the group ID `notification-service-group`.
- **Log Received Order ID:** Implemented logging of the received order ID from the Kafka message.

### Purpose:
The purpose of this pull request is to enable the Notification Service to receive and process order notifications published by the Order Service to the `notificationTopic` Kafka topic. The `NotificationService` class contains a method annotated with `@KafkaListener` that listens for messages on the `notificationTopic` Kafka topic. When a message is received, the `listen` method is invoked, and it logs the order ID received from the message. This allows the Notification Service to receive and process order notifications for further actions, such as sending notifications to customers or triggering additional workflows.