### PR TITLE
Add Docker Configuration Properties for Inventory Service

### DIFF
--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,0 +1,13 @@
+server.port=8080
+
+# Logging level
+logging.level.org.springframework.security=TRACE
+
+# Eureka Server URL
+eureka.client.serviceUrl.defaultZone=http://root:root@discovery-server:8761/eureka
+
+# Zipkin Configuration
+management.zipkin.tracing.endpoint=http://zipkin:9411
+
+# Kafka Bootstrap Server Property
+spring.kafka.consumer.bootstrap-servers=kafka:29092


### PR DESCRIPTION
### Description:
This pull request introduces a new configuration file for the Docker environment in the `notification-service` project.

### Changes:
- **Docker Environment Configuration:** Create a new `application-docker.properties` file for Docker environment configuration.
- **Server Port:** Set the server port to `8080` in the Docker environment.
- **Logging Level:** Configure the logging level for Spring Security to `TRACE`.
- **Eureka Server URL:** Set the Eureka server URL for the Docker environment to `http://root:root@discovery-server:8761/eureka`.
- **Zipkin Tracing Endpoint:** Configure the Zipkin tracing endpoint for the Docker environment to `http://zipkin:9411`.
- **Kafka Bootstrap Server:** Set the Kafka consumer bootstrap server property for the Docker environment to `kafka:29092`.

### Purpose:
The purpose of this pull request is to introduce a separate configuration file `application-docker.properties` for the Docker environment. This file contains environment-specific configurations, such as the server port, logging level, Eureka server URL, Zipkin tracing endpoint, and Kafka bootstrap server. By separating the Docker environment configuration from the main `application.properties` file, it becomes easier to manage and maintain environment-specific settings, improving code organization and maintainability.