### PR TITLE
Add Prometheus Metrics Support to Notification Service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-tracing-bridge-brave</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,6 @@ management.tracing.sampling.probability=1.0
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 spring.kafka.consumer.group-id=notification-service-group
+
+# Actuator Prometheus Endpoint
+management.endpoints.web.exposure.include=prometheus


### PR DESCRIPTION
### Description:
This pull request introduces changes to enable Prometheus metrics collection and monitoring in the Notification Service microservice.

### Changes:
- **Add Prometheus Metrics Support:** Added dependency for `micrometer-registry-prometheus` to enable Prometheus metrics collection.
- **Configure Prometheus Endpoint:** Configured Prometheus actuator endpoint in `application.properties` by adding `management.endpoints.web.exposure.include=prometheus`.

### Purpose:
The purpose of this pull request is to integrate the Notification Service microservice with Prometheus for monitoring and collecting metrics. By adding the Prometheus registry and exposing the Prometheus actuator endpoint, the Notification Service can be scraped by Prometheus, allowing for visualization and analysis of various metrics such as request rates, response times, and system resource utilization. This enhancement improves observability and aids in monitoring the health and performance of the Notification Service.